### PR TITLE
Add optional image preview (REPTILE_PREVIEW_PATH), image crate and UI tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "jpeg-decoder",
  "num-traits",
  "png",
 ]
@@ -1820,6 +1821,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2602,6 +2609,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "eframe",
+ "image",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 eframe = { version = "0.27", default-features = true }
 chrono = { version = "0.4", features = ["clock"] }
 rand = "0.8"
+image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ cargo check
 cargo run
 ```
 
+Avec image locale d'aperçu (JPEG/PNG) :
+
+```bash
+REPTILE_PREVIEW_PATH=/chemin/animal.jpg cargo run
+```
+
 ## Cross-build cible RISC-V
 
 ```bash
@@ -46,6 +52,7 @@ Binaire produit:
 
 - L'application démarre sans panic.
 - En-tête `ThermoOS` visible.
+- Le panneau `APERÇU ANIMAL` affiche l'image si `REPTILE_PREVIEW_PATH` est défini vers un fichier lisible, sinon affiche un message d'aide.
 - 4 cartes de zones visibles (chaude/intermédiaire/humide/bassin).
 - Chaque carte affiche les tags ÉCLAIRAGE/UVA/UVB/6500K/CHAUF/POMPE.
 - Les valeurs temp/hygro varient automatiquement toutes ~1.2 s.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use chrono::Local;
 use eframe::egui::{self, Color32, RichText, Stroke};
+use image::io::Reader as ImageReader;
 use rand::Rng;
+use std::env;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 fn main() -> eframe::Result<()> {
@@ -31,6 +34,8 @@ struct Zone {
     lux_on: bool,
     kelvin_6500_on: bool,
     color: Color32,
+    day_runtime: &'static str,
+    night_runtime: &'static str,
 }
 
 impl Zone {
@@ -96,12 +101,15 @@ struct ThermoApp {
     reptile: ReptileInfo,
     astro: AstroCycle,
     system: SystemState,
+    preview_texture: Option<egui::TextureHandle>,
+    preview_status: String,
     last_tick: Instant,
 }
 
 impl ThermoApp {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
+        let (preview_texture, preview_status) = load_preview_texture(&cc.egui_ctx);
 
         Self {
             zones: vec![
@@ -119,6 +127,8 @@ impl ThermoApp {
                     lux_on: true,
                     kelvin_6500_on: false,
                     color: Color32::from_rgb(255, 168, 38),
+                    day_runtime: "--/--",
+                    night_runtime: "--/--",
                 },
                 Zone {
                     name: "zone intermédiaire",
@@ -134,6 +144,8 @@ impl ThermoApp {
                     lux_on: true,
                     kelvin_6500_on: false,
                     color: Color32::from_rgb(255, 214, 64),
+                    day_runtime: "--/--",
+                    night_runtime: "--/--",
                 },
                 Zone {
                     name: "zone humide",
@@ -149,6 +161,8 @@ impl ThermoApp {
                     lux_on: true,
                     kelvin_6500_on: false,
                     color: Color32::from_rgb(33, 212, 253),
+                    day_runtime: "--/--",
+                    night_runtime: "--/--",
                 },
                 Zone {
                     name: "bassin",
@@ -164,6 +178,8 @@ impl ThermoApp {
                     lux_on: true,
                     kelvin_6500_on: false,
                     color: Color32::from_rgb(140, 255, 229),
+                    day_runtime: "--/--",
+                    night_runtime: "--/--",
                 },
             ],
             reptile: ReptileInfo {
@@ -196,6 +212,8 @@ impl ThermoApp {
                 wifi: true,
                 bluetooth: true,
             },
+            preview_texture,
+            preview_status,
             last_tick: Instant::now(),
         }
     }
@@ -257,6 +275,10 @@ impl ThermoApp {
                     zone.status_humidity(),
                     zone.co2_ppm
                 ));
+                ui.small(format!(
+                    "Jour {}  •  Nuit {}",
+                    zone.day_runtime, zone.night_runtime
+                ));
             });
     }
 }
@@ -269,17 +291,21 @@ impl eframe::App for ThermoApp {
         }
 
         egui::TopBottomPanel::top("header").show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.heading(RichText::new("ThermoOS").color(Color32::from_rgb(126, 217, 255)));
-                ui.separator();
-                ui.label(Local::now().format("%d %b %Y  %H:%M").to_string());
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if self.system.bluetooth {
-                        ui.label("BT✓");
-                    }
-                    if self.system.wifi {
-                        ui.label("Wi‑Fi✓");
-                    }
+            ui.columns(3, |cols| {
+                cols[0].label(Local::now().format("%a %d %b  %H:%M").to_string());
+                cols[1].with_layout(
+                    egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
+                    |ui| {
+                        ui.heading(
+                            RichText::new("ThermoOS").color(Color32::from_rgb(126, 217, 255)),
+                        );
+                    },
+                );
+                cols[2].with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label("⚙");
+                    ui.label(if self.system.wifi { "📶" } else { "📴" });
+                    ui.label(if self.system.bluetooth { "◉" } else { "○" });
+                    ui.label("🔔");
                 });
             });
         });
@@ -290,14 +316,26 @@ impl eframe::App for ThermoApp {
                 ui.group(|ui| {
                     ui.label(RichText::new("APERÇU ANIMAL").strong());
                     ui.add_space(8.0);
-                    ui.allocate_ui_with_layout(
-                        egui::vec2(ui.available_width(), 160.0),
-                        egui::Layout::top_down(egui::Align::Center),
-                        |ui| {
-                            ui.label("[Image caméra / fichier non configuré]");
-                            ui.small("Astuce: intégrer une texture egui via include_bytes!()");
-                        },
-                    );
+                    let image_height = 160.0;
+                    let image_size = egui::vec2(ui.available_width(), image_height);
+
+                    if let Some(texture) = &self.preview_texture {
+                        let image = egui::Image::new(texture).fit_to_exact_size(image_size);
+                        ui.add(image);
+                        ui.small("Source: REPTILE_PREVIEW_PATH");
+                    } else {
+                        let (rect, _) = ui.allocate_exact_size(image_size, egui::Sense::hover());
+                        ui.painter()
+                            .rect_filled(rect, 6.0, Color32::from_rgb(58, 58, 58));
+                        ui.painter().text(
+                            rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            "Flux caméra non configuré",
+                            egui::FontId::proportional(16.0),
+                            Color32::LIGHT_GRAY,
+                        );
+                        ui.small(&self.preview_status);
+                    }
                 });
 
                 ui.add_space(8.0);
@@ -378,6 +416,36 @@ fn tag(ui: &mut egui::Ui, label: &str, on: bool) {
 fn key_val(ui: &mut egui::Ui, k: &str, v: &str) {
     ui.horizontal(|ui| {
         ui.colored_label(Color32::GRAY, k);
-        ui.label(v);
+        let value_color = match v {
+            "ON" => Color32::LIGHT_GREEN,
+            "OFF" => Color32::LIGHT_RED,
+            _ => Color32::WHITE,
+        };
+        ui.colored_label(value_color, v);
     });
+}
+
+fn load_preview_texture(ctx: &egui::Context) -> (Option<egui::TextureHandle>, String) {
+    let var_name = "REPTILE_PREVIEW_PATH";
+    let path_value = match env::var(var_name) {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return (None, format!("Définir {var_name}=/chemin/vers/image.jpg")),
+    };
+
+    let path = Path::new(&path_value);
+    let reader = match ImageReader::open(path) {
+        Ok(r) => r,
+        Err(err) => return (None, format!("Impossible d'ouvrir {path_value}: {err}")),
+    };
+
+    let decoded = match reader.decode() {
+        Ok(img) => img,
+        Err(err) => return (None, format!("Décodage image impossible: {err}")),
+    };
+
+    let rgba = decoded.to_rgba8();
+    let size = [rgba.width() as usize, rgba.height() as usize];
+    let color_image = egui::ColorImage::from_rgba_unmultiplied(size, rgba.as_raw());
+    let texture = ctx.load_texture("reptile-preview", color_image, egui::TextureOptions::LINEAR);
+    (Some(texture), format!("Image chargée: {path_value}"))
 }


### PR DESCRIPTION
### Motivation
- Provide an optional local image preview for the "APERÇU ANIMAL" panel driven by an environment variable to make it easy to show a sample JPEG/PNG without camera integration.
- Improve header and status presentation and display per-zone day/night runtime placeholders for richer UI feedback.

### Description
- Added the `image` dependency (disabled default features) to `Cargo.toml` and updated `Cargo.lock` to include `jpeg-decoder` and the `image` package.
- Implemented `load_preview_texture` which reads `REPTILE_PREVIEW_PATH`, decodes the image via `image::io::Reader`, converts to an `egui::ColorImage` and loads an `egui::TextureHandle`, and wired it into `ThermoApp` (`preview_texture` and `preview_status`).
- Updated `Zone` to include `day_runtime` and `night_runtime` fields and display them in the zone card; adjusted header layout and status icons, and improved `key_val` coloring logic.
- Updated `README.md` with usage instructions for `REPTILE_PREVIEW_PATH` and a note describing preview behavior when the variable is set or not.

### Testing
- Ran `cargo check` which completed successfully after the dependency changes.
- Performed a local `cargo build --release` which succeeded and allowed manual verification of the UI preview fallback and image loading behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dffaec332c8323893069461f898b2c)